### PR TITLE
Fix SSM into EC2 command

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ You can access application from output value of `ComfyUIStack.Endpoint`.
 
 ```bash
 # 1. SSM into EC2
-aws ssm start-session --target "$(aws ec2 describe-instances --filters "Name=tag:Name,Values=ComfyUIStack/ASG" "Name=instance-state-name,Values=running" --query 'Reservations[*].Instances[*].[InstanceId]' --output text)" --region $AWS_DEFAULT_REGION
+aws ssm start-session --target "$(aws ec2 describe-instances --filters "Name=tag:Name,Values=ComfyUIStack/Host" "Name=instance-state-name,Values=running" --query 'Reservations[].Instances[].[InstanceId]' --output text)" --region $AWS_DEFAULT_REGION
 
 # 2. SSH into Container
 container_id=$(sudo docker container ls --format '{{.ID}} {{.Image}}' | grep 'comfyui:latest$' | awk '{print $1}')


### PR DESCRIPTION
This PR fixes the SSM command used to connect to the EC2 instance. The change updates the filter used in the AWS CLI command to correctly identify the target EC2 instance.

Specifically:
- Changed the filter "Name=tag:Name,Values=ComfyUIStack/ASG" to "Name=tag:Name,Values=ComfyUIStack/Host"
- Updated the --query parameter to simplify the output format

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.