### PR TITLE
Deployment Option: SageMaker Studio Code Editor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN useradd -m -u 1000 user
 USER user
 ENV HOME=/home/user \
     PATH=/home/user/.local/bin:$PATH
+RUN mkdir -p /home/user/opt/ComfyUI && chown -R user /home/user/opt/ComfyUI
 
 # Pyenv and Python setup
 RUN curl https://pyenv.run | bash

--- a/README.md
+++ b/README.md
@@ -38,30 +38,17 @@ This sample repository provides a seamless and cost-effective solution to deploy
 
 ### Prepare the AWS environment
 
-For the sake of reproducability and consistency, we recommend using [AWS Cloud9](https://docs.aws.amazon.com/cloud9/latest/user-guide/welcome.html) IDE for deploying and testing this solution.
+For the sake of reproducability and consistency, we recommend using [Amazon SageMaker Studio Code Editor](https://docs.aws.amazon.com/sagemaker/latest/dg/code-editor.html) for deploying and testing this solution.
 
 ℹ️ You can use your local development environment, but you will need to **make sure that you have AWS CLI, AWS CDK and Docker properly setup**. Additionally, if you're building your docker image using apple chips (M1, M2, etc.) then you need to use the Docker ```docker build --platform linux/amd64 .``` command.
 
 <details>
-<summary>Click to see environment setup with Cloud9</summary>
+<summary>Click to see environment estup with Amazon SageMaker Studio Code Editor</summary>
 
-1. Login to AWS Console
-2. Navigate to Cloud9
-3. Create Environment with following example details:
-    - Name: Give your Dev Environment a name of choice
-    - Instance Type: t2.micro (default) got a free-tier
-    - Platform: Ubuntu Server 22.04 LTS
-    - Timeout: 30 minutes
-    - Other settings can be configured with the default values
-4. Create and open environment
-5. resize disk space
-    ```bash
-    curl -o resize.sh https://raw.githubusercontent.com/aws-samples/semantic-search-aws-docs/main/cloud9/resize.sh
-    chmod +x ./resize.sh
-    ./resize.sh 100
-    ```
-6. git clone <enter this repo URL here>
-7. cd into new directory
+1. Launch Amazon SageMaker Studio Code Editor using CloudFormation template from link in [sagemaker-studio-code-editor-template](https://github.com/aws-samples/sagemaker-studio-code-editor-template/). (This template launches Code Editor with some necessary capabilities including Docker, auto termination)
+2. Open SageMaker Studio from url in CloudFormation Output.
+3. Navigate to Code Editor from Application section in top left.
+4. Install CDK by `npm install -g aws-cdk`
 </details>
 
 <details>
@@ -82,12 +69,35 @@ aws configure
 When prompted, enter your AWS Access Key ID, Secret Access Key, and then the default region name (eg. us-east-1). You can leave the output format field as default or specify it as per your preference.
 </details>
 
-After setting up environment, set environment variable below. These variables will be used in many of the commands below.
+<details>
+<summary>(Deprecated) Click to see environment setup with Cloud9</summary>
+
+1. Login to AWS Console
+2. Navigate to Cloud9
+3. Create Environment with following example details:
+    - Name: Give your Dev Environment a name of choice
+    - Instance Type: t2.micro (default) got a free-tier
+    - Platform: Ubuntu Server 22.04 LTS
+    - Timeout: 30 minutes
+    - Other settings can be configured with the default values
+4. Create and open environment
+5. resize disk space
+    ```bash
+    curl -o resize.sh https://raw.githubusercontent.com/aws-samples/semantic-search-aws-docs/main/cloud9/resize.sh
+    chmod +x ./resize.sh
+    ./resize.sh 100
+    ```
+</details>
+
+### Setup environment
+
+1. (First time only) Clone this repo
+2. (First time only) cd into repo directory
+3. Set environment variable below. These variables will be used in many of the commands below.
 
 ```bash
 export AWS_DEFAULT_REGION=<aws_region> # e.g. "us-east-1", "eu-central-1"
 export AWS_DEFAULT_ACCOUNT=<your_account_id> # e.g. 123456789012
-export ECR_REPO_NAME="comfyui"
 ```
 
 ### Build & push docker image to ECR
@@ -97,22 +107,24 @@ for vulnerabilites as soon as you push the image to ECR. You can achieve this as
 
 1. Create an ECR repository and login
 ```
-aws ecr create-repository --repository-name $ECR_REPO_NAME --image-scanning-configuration scanOnPush=true
+aws ecr create-repository --repository-name comfyui --image-scanning-configuration scanOnPush=true
 ```
 2. Login to ECR
 ```
-aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $AWS_DEFAULT_ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPO_NAME
+aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $AWS_DEFAULT_ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/comfyui
 ```
 3. Build docker image (make sure you're in the same directory as your dockerfile)
 ```
 docker build -t comfyui .
 # or alternatively if you are using M1 / M2 / ... Mac
 docker build --platform linux/amd64 -t comfyui .
+# or alternatively if you are using SageMaker Studio Code Editor
+docker build -t comfyui . --network sagemaker
 ```
 4. Tag and push docker image to ECR
 ```
-docker tag comfyui:latest $AWS_DEFAULT_ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPO_NAME:latest
-docker push $AWS_DEFAULT_ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPO_NAME:latest
+docker tag comfyui:latest $AWS_DEFAULT_ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/comfyui:latest
+docker push $AWS_DEFAULT_ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/comfyui:latest
 ```
 
 ### Deploying ComfyUI

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 aws-cdk-lib==2.150.0
-aws-cdk.aws-lambda-python-alpha==2.150.0a0
 constructs>=10.0.0,<11.0.0
 boto==2.49.0
 cdk-nag>=2.28.0


### PR DESCRIPTION
*Issue #, if available:*
#9 

*Description of changes:*
- Add SageMaker Studio Code Editor deployment and deprecate Cloud9
  - Replace aws-lambda-python-alpha with aws-lambda with custom bundling command to build with --network sagemaker
  - Fix Dockerfile to support build with sagemaker studio (explicitly create folder with user permission)
  - Update docs
- chore: remove hardcoded resource name to support deploy multiple stack in same region

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
