### PR TITLE
Revert "chore: add circuit breaker"

### DIFF
--- a/comfyui_aws_stack/comfyui_aws_stack.py
+++ b/comfyui_aws_stack/comfyui_aws_stack.py
@@ -444,10 +444,6 @@ class ComfyUIStack(Stack):
             security_groups=[service_security_group],
             health_check_grace_period=Duration.seconds(30),
             min_healthy_percent=0,
-            circuit_breaker=ecs.DeploymentCircuitBreaker(
-                enable=True,
-                rollback=True
-            )
         )
 
         # Application Load Balancer


### PR DESCRIPTION
Reverts aws-samples/cost-effective-aws-deployment-of-comfyui#17

- ECS deploy needs to wait EC2 launch and circuit breaker may decide to roll back while waiting for EC2