### PR TITLE
fix: update rexray to support imdsv2

### DIFF
--- a/comfyui_aws_stack/construct/asg_construct.py
+++ b/comfyui_aws_stack/construct/asg_construct.py
@@ -56,7 +56,7 @@ class AsgConstruct(Construct):
         user_data_script.add_commands("""
             #!/bin/bash
             REGION=$(curl -s http://169.254.169.254/latest/meta-data/placement/region) 
-            docker plugin install rexray/ebs --grant-all-permissions REXRAY_PREEMPT=true EBS_REGION=$REGION
+            docker plugin install public.ecr.aws/j1l5j1d1/rexray-ebs --grant-all-permissions REXRAY_PREEMPT=true EBS_REGION=$REGION
             systemctl restart docker
         """)
 

--- a/comfyui_aws_stack/construct/ecs_construct.py
+++ b/comfyui_aws_stack/construct/ecs_construct.py
@@ -83,7 +83,7 @@ class EcsConstruct(Construct):
             name="ComfyUIVolume-" + suffix,
             docker_volume_configuration=ecs.DockerVolumeConfiguration(
                 scope=ecs.Scope.SHARED,
-                driver="rexray/ebs",
+                driver="public.ecr.aws/j1l5j1d1/rexray-ebs",
                 driver_opts={
                     "volumetype": "gp3",
                     "size": "250"  # Size in GiB


### PR DESCRIPTION
*Issue #, if available:*
#7 
#8 

*Description of changes:*
- rexray/ebs only supports imdsv1 and account with account level setting imdsv2=required, ecs task fails to launch.
- Migrating to public.ecr.aws/j1l5j1d1/rexray-ebs which is fork of rexray supporting imdsv2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
